### PR TITLE
Upgrade ssh2 sftp client for using node18

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,4 +1,3 @@
-const path = require('path');
 const getSFTPConnection = require('./utils/getSFTPConnection');
 
 module.exports = {
@@ -10,21 +9,10 @@ module.exports = {
     return {
       upload: async (file) => {
         const sftp = await connection();
-        const files = await sftp.list(basePath);
-
         let fileName = `${file.hash}${file.ext}`;
-        let c = 0;
-
-        const hasName = f => f.name === fileName;
-
-        // scans directory files to prevent files with the same name
-        while (files.some(hasName)) {
-          c += 1;
-          fileName = `${file.hash}(${c})${file.ext}`;
-        }
 
         try {
-          await sftp.put(file.buffer, path.resolve(basePath, fileName))
+          await sftp.put(file.buffer, `${basePath}/${fileName}`)
         } catch (e) {
           console.error(e);
         }

--- a/package.json
+++ b/package.json
@@ -25,19 +25,23 @@
     "email": "info@finnoconsult.at",
     "url": "https://finnoconsult.at"
   },
-  "contributors": [{
-    "name": "Márk Pap",
-    "email": "mark.pap@finnoconsult.at",
-    "url": "https://github.com/Sqveeze"
-  }, {
-    "name": "Péter Horváth",
-    "email": "peter.horvath@finnoconsult.at",
-    "url": "https://github.com/pitiboy"
-  }, {
-    "name": "Levente Máthé",
-    "email": "levente.mathe@finnoconsult.at",
-    "url": "https://github.com/leventemathefc"
-  }],
+  "contributors": [
+    {
+      "name": "Márk Pap",
+      "email": "mark.pap@finnoconsult.at",
+      "url": "https://github.com/Sqveeze"
+    },
+    {
+      "name": "Péter Horváth",
+      "email": "peter.horvath@finnoconsult.at",
+      "url": "https://github.com/pitiboy"
+    },
+    {
+      "name": "Levente Máthé",
+      "email": "levente.mathe@finnoconsult.at",
+      "url": "https://github.com/leventemathefc"
+    }
+  ],
   "bugs": {
     "url": "https://github.com/finnoconsult/strapi-provider-upload-sftp/issues"
   },
@@ -54,7 +58,7 @@
     "jest": "^25.4.0"
   },
   "dependencies": {
-    "ssh2-sftp-client": "^2.5.0"
+    "ssh2-sftp-client": "9.1.0"
   },
   "scripts": {
     "test": "jest --detectOpenHandles --forceExit --setupFiles dotenv/config",


### PR DESCRIPTION
- upgraded "ssh2-sftp-client" to latest for using node18
- removed not required "path" (it also didn't work on Windows)
- removed excess file counter (files use hash)